### PR TITLE
[feat] Add Sendbird UIKit ViewController #10

### DIFF
--- a/Techeer-RUAlone.xcodeproj/project.pbxproj
+++ b/Techeer-RUAlone.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		0B29ED0F294B080B00A2D8FA /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B29ED0E294B080B00A2D8FA /* View+Extension.swift */; };
 		0B29ED11294B185800A2D8FA /* FeedRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B29ED10294B185800A2D8FA /* FeedRowView.swift */; };
 		0BC42351294B373200188283 /* SuggestionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC42350294B373200188283 /* SuggestionView.swift */; };
+		0BC4235729599A0C00188283 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC4235629599A0C00188283 /* ChatView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +75,7 @@
 		0B29ED0E294B080B00A2D8FA /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		0B29ED10294B185800A2D8FA /* FeedRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedRowView.swift; sourceTree = "<group>"; };
 		0BC42350294B373200188283 /* SuggestionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionView.swift; sourceTree = "<group>"; };
+		0BC4235629599A0C00188283 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -144,6 +146,7 @@
 				0B29ED10294B185800A2D8FA /* FeedRowView.swift */,
 				0BC42350294B373200188283 /* SuggestionView.swift */,
 				042A83122951D198001F3FE0 /* MesseageRowView.swift */,
+				0BC4235629599A0C00188283 /* ChatView.swift */,
 			);
 			path = "Techeer-RUAlone";
 			sourceTree = "<group>";
@@ -343,6 +346,7 @@
 				0B0682B32944C7CC00E5D648 /* HomeView.swift in Sources */,
 				042A83112950E96B001F3FE0 /* MessageView.swift in Sources */,
 				0B29ED0F294B080B00A2D8FA /* View+Extension.swift in Sources */,
+				0BC4235729599A0C00188283 /* ChatView.swift in Sources */,
 				042A83132951D198001F3FE0 /* MesseageRowView.swift in Sources */,
 				0B06822829370AC000E5D648 /* ContentView.swift in Sources */,
 				0B0682BB2944D1AE00E5D648 /* VerticalRectangle.swift in Sources */,

--- a/Techeer-RUAlone/ChatView.swift
+++ b/Techeer-RUAlone/ChatView.swift
@@ -1,0 +1,53 @@
+//
+//  ChatView.swift
+//  Techeer-RUAlone
+//
+//  Created by Sean Hong on 2022/12/26.
+//
+
+import SwiftUI
+import SendbirdUIKit
+
+struct ChatView: View {
+    let appID = "B63A605C-5AA3-4540-A296-83CAFB32E557"
+    let channelURL = "sendbird_group_channel_104288745_01714e67ffa2f3be0dbf8796492e06c172bdc321"
+    
+    init() {
+        SendbirdUI.initialize(applicationId: appID) { (error) in
+            print("Sendbird Init: Initialization Error \(String(describing: error))")
+        }
+        SBUGlobals.currentUser = SBUUser(userId: "Test")
+        SendbirdUI.connect { (user, error) in
+            guard let _ = user else {
+                print("Sendbird Init: Connection Error \(String(describing: error))")
+                return
+            }
+        }
+    }
+    var body: some View {
+        ChatViewContainer(channelURL: channelURL)
+    }
+}
+
+struct ChatViewContainer: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let channel = SendbirdUIKitController(channelURL: channelURL)
+        let navigationViewController = UINavigationController(rootViewController: channel)
+        return navigationViewController
+    }
+    
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) { }
+    
+    typealias UIViewControllerType = UINavigationController
+    let channelURL: String
+}
+
+class SendbirdUIKitController: SBUGroupChannelViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+    }
+}


### PR DESCRIPTION
채팅 기능을 위해 Sendbird 에서 제공하는 UIKit SDK를 SwiftUI 에서 사용하기 위해 ViewControllerRepresentable을 작성했습니다.

결과는 UI의 결과는 아래와 같습니다. 
참고로 해당 View 는 추후 개발되는 04_Feed_Detail(Figma 참고해 주세요!) 에서 참여하기 버튼 클릭 시 채팅 방으로 연결되는 방식으로 사용할 것 같습니다. 
아래 캡쳐는 그냥 이렇게 생겼구나~ 라고 생각하시고 참고만 하시면 됩니다!
![Screenshot 2022-12-26 at 6 02 00 PM](https://user-images.githubusercontent.com/35219323/209528960-5dc85800-a092-44c6-a2ca-1aab1eea69d6.png)
